### PR TITLE
bench.chat → bench.io

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -117,4 +117,4 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/bench-v}
 
           # Build and push Docker image
-          docker build -t chatbench/cli:latest -t chatbench/cli:$VERSION .
+          docker build -t bench-chat/cli:latest -t bench-chat/cli:$VERSION .

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 name = "bench"
 version = "0.1.0"
 edition = "2021"
-authors = ["Bench Computing <admin@bench.chat>"]
+authors = ["Bench Computing <admin@bench.io>"]
 description = "Bench CLI tool"
-repository = "https://github.com/chatbench/bench"
+repository = "https://github.com/bench-chat/bench"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser"] }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Download the latest release for your platform from the [releases page](https://g
 
 2. Clone the repository:
 ```bash
-git clone https://github.com/chatbench/bench
+git clone https://github.com/bench-chat/bench-cli
 cd bench
 ```
 
@@ -44,7 +44,7 @@ docker-compose run --rm bench
 
 Or directly with Docker:
 ```bash
-docker run -it --rm -v ~/.bench/root:/home/bench chatbench/cli:latest
+docker run -it --rm -v ~/.bench/root:/home/bench bench-cli/cli:latest
 ```
 
 The entire home directory of the bench user inside the container will be persisted to `~/.bench/root` on your host system, including:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   bench:
-    image: chatbench/cli:latest
+    image: bench-chat/cli:latest
     volumes:
       - ~/.bench/root:/home/bench
     stdin_open: true

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ impl Config {
     pub fn new(env: &Environment) -> anyhow::Result<Self> {
         let base_url = match env {
             Environment::Local => Url::parse("http://localhost:3001")?,
-            Environment::Production => Url::parse("https://bench.chat")?,
+            Environment::Production => Url::parse("https://bench.io")?,
             Environment::Custom(url) => Url::parse(url)?,
         };
         Ok(Self { base_url })


### PR DESCRIPTION
swap the domain (and github org) to new location